### PR TITLE
branches: change master to main

### DIFF
--- a/_episodes/07-branches.md
+++ b/_episodes/07-branches.md
@@ -10,18 +10,18 @@ objectives:
 - "*working on separate tasks in the same repository concurrently*"
 - "*trying multiple solutions to a problem*"
 - "*check-pointing versions of code*"
-- "Merge branches back into the master branch"
+- "Merge branches back into the main branch"
 keypoints:
-- "Branches can be useful for developing while keeping the main line static."
+- "Branches can be useful for developing while keeping the primary work untouched."
 ---
 
 So far we've always been working in a straight timeline.
 However, there are times when we might want to keep
-our main work safe from experimental changes we are working on.
+our primary work safe from experimental changes we are working on.
 To do this we can use branches to work on separate tasks in parallel
-without changing our current branch, `master`.
+without changing our current branch, `main`.
 
-We didn't see it before but the first branch made is called `master`.
+We didn't see it before but the first branch made is called `main`.
 This is the default branch created when initializing a repository and
 is often considered to be the "clean" or "working" version of a
 repository's code.
@@ -34,7 +34,7 @@ $ git branch
 {: .bash}
 
 ~~~
-* master
+* main
 ~~~
 {: .output}
 
@@ -43,10 +43,10 @@ The '*' indicates which branch we are currently on.
 
 In this lesson, Dracula is trying to run an analysis
 and doesn't know if it will be faster in bash or python.
-To keep his master branch safe he will use separate branches
+To keep his main branch safe he will use separate branches
 for both bash and python analysis.
 Then he will merge the branch with the faster script
-into his master branch.
+into his main branch.
 
 First let's make the python branch.
 We use the same `git branch` command but now add the 
@@ -65,13 +65,13 @@ $ git branch
 {: .bash}
 
 ~~~
-* master
+* main
   pythondev
 ~~~
 {: .output}
 
 We can see that we created the `pythondev` branch but we
-are still in the master branch.
+are still in the main branch.
 
 We can also see this in the output of the `git status` command.
 
@@ -81,7 +81,7 @@ $ git status
 {: .bash}
 
 ~~~
-On branch master
+On branch main
 nothing to commit, working directory clean
 ~~~
 {: .output}
@@ -96,7 +96,7 @@ $ git branch
 {: .bash}
 
 ~~~
-  master
+  main
 * pythondev
 ~~~
 {: .output}
@@ -113,7 +113,7 @@ a nickname to checkout a version of the repository that matches the most recent
 commit in that branch (a.k.a. the HEAD of that branch).
 
 Here you can use `git log` and `ls` to see that the history and 
-files are the same as our `master` branch. This will be true until
+files are the same as our `main` branch. This will be true until
 some changes are committed to our new branch.
 
 Now lets make our python script.  
@@ -150,24 +150,24 @@ $ git log --oneline
 
 As expected, we see our commit in the log.
 
-Now let's switch back to the `master` branch.
+Now let's switch back to the `main` branch.
 
 ~~~
-$ git checkout master
+$ git checkout main
 $ git branch
 ~~~
 {: .bash}
 
 ~~~
-* master
+* main
   pythondev
 ~~~
 {: .output}
 
 Let's explore the repository a bit.
 
-Now that we've confirmed we are on the `master` branch again.
-Let's confirm that `analysis.py` and our last commit aren't in `master`.
+Now that we've confirmed we are on the `main` branch again.
+Let's confirm that `analysis.py` and our last commit aren't in `main`.
 
 ~~~
 $ ls
@@ -187,7 +187,7 @@ $ git branch
 {: .bash}
 
 ~~~
-  master
+  main
 * pythondev
 ~~~
 {: .output}
@@ -204,18 +204,18 @@ preserved in the `pythondev` branch.
 Now we can repeat the process for our bash script in a branch called
 `bashdev`.
 
-First we must checkout the `master` branch again. New branches will
+First we must checkout the `main` branch again. New branches will
 include the entire history up to the current commit, and we'd like
 to keep these two tasks separate.
 
 ~~~
-$ git checkout master
+$ git checkout main
 $ git branch
 ~~~
 {: .bash}
 
 ~~~
-* master
+* main
   pythondev
 ~~~
 {: .output}
@@ -233,14 +233,14 @@ $ git branch
 
 ~~~
 * bashdev
-  master
+  main
   pythonndev
 ~~~
 {: .output}
 
 
 We can use `ls` and `git log` to see that this branch is 
-the same as our current `master` branch.
+the same as our current `main` branch.
 
 Now we can make `analysis.sh` and add and commit it.
 Again imagine instead of `touch`ing the file we worked 
@@ -260,7 +260,7 @@ $ git commit –m “Wrote and tested bash analysis script”
 ~~~
 {: .output}
 
-Lets check our work again before we switch back to the master branch.
+Lets check our work again before we switch back to the main branch.
 ~~~
 $ ls
 $ git log --oneline
@@ -269,29 +269,29 @@ $ git log --oneline
 
 So it turns out the python `analysis.py` is much faster than `analysis.sh`.
 
-Let's merge this version into our `master` branch so we can use it for
+Let's merge this version into our `main` branch so we can use it for
 our work going forward.
 
 Merging brings the changes from a different branch into 
 the current branch.
 
-First we must switch to the branch we're merging changes into, `master`.
+First we must switch to the branch we're merging changes into, `main`.
 
 ~~~
-$ git checkout master
+$ git checkout main
 $ git branch
 ~~~
 {: .bash}
 
 ~~~
   bashdev
-* master
+* main
   pythonndev
 ~~~
 {: .output}
 
 Now we can `merge` the `pythondev` branch into our current branch
-(`master`). In english, this command could be stated as "`git`, please
+(`main`). In english, this command could be stated as "`git`, please
 `merge` the changes in the `pythondev` branch into the current branch
 I'm in".
 
@@ -309,7 +309,7 @@ Fast-forward
 ~~~
 {: .output}
 
-Now that we've merged the `pythondev` into `master`, these changes
+Now that we've merged the `pythondev` into `main`, these changes
 exist in both branches. This could be confusing in the future if we
 stumble upon the `pythondev` branch again.
 


### PR DESCRIPTION
Changed occurences of "master" to "main" as this is what GitHub uses these days.